### PR TITLE
refactor: use more specific model for workflow parameters (#339)

### DIFF
--- a/app/apis/catalog/brc-analytics-catalog/common/entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/entities.ts
@@ -1,4 +1,8 @@
-import { ORGANISM_PLOIDY, WORKFLOW_PLOIDY } from "./schema-entities";
+import {
+  ORGANISM_PLOIDY,
+  WORKFLOW_PARAMETER_VARIABLE,
+  WORKFLOW_PLOIDY,
+} from "./schema-entities";
 
 export type BRCCatalog = BRCDataCatalogGenome;
 
@@ -71,11 +75,15 @@ export interface WorkflowCategory {
 }
 
 export interface Workflow {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- True type is something like { [key: string]: string | string[] }, but can't model with linkml
-  parameters: any;
+  parameters: WorkflowParameter[];
   ploidy: WORKFLOW_PLOIDY;
   taxonomyId: string | null;
   trsId: string;
   workflowDescription: string;
   workflowName: string;
+}
+
+export interface WorkflowParameter {
+  key: string;
+  variable: WORKFLOW_PARAMETER_VARIABLE;
 }

--- a/app/apis/catalog/brc-analytics-catalog/common/schema-entities.ts
+++ b/app/apis/catalog/brc-analytics-catalog/common/schema-entities.ts
@@ -1,4 +1,5 @@
 export {
   OrganismPloidy as ORGANISM_PLOIDY,
+  WorkflowParameterVariable as WORKFLOW_PARAMETER_VARIABLE,
   WorkflowPloidy as WORKFLOW_PLOIDY,
 } from "../../../../../catalog/schema/generated/schema";

--- a/catalog/build/py/generated_schema/schema.py
+++ b/catalog/build/py/generated_schema/schema.py
@@ -1,0 +1,228 @@
+from __future__ import annotations 
+
+import re
+import sys
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from decimal import Decimal 
+from enum import Enum 
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator
+)
+
+
+metamodel_version = "None"
+version = "None"
+
+
+class ConfiguredBaseModel(BaseModel):
+    model_config = ConfigDict(
+        validate_assignment = True,
+        validate_default = True,
+        extra = "forbid",
+        arbitrary_types_allowed = True,
+        use_enum_values = True,
+        strict = False,
+    )
+    pass
+
+
+
+
+class LinkMLMeta(RootModel):
+    root: Dict[str, Any] = {}
+    model_config = ConfigDict(frozen=True)
+
+    def __getattr__(self, key:str):
+        return getattr(self.root, key)
+
+    def __getitem__(self, key:str):
+        return self.root[key]
+
+    def __setitem__(self, key:str, value):
+        self.root[key] = value
+
+    def __contains__(self, key:str) -> bool:
+        return key in self.root
+
+
+linkml_meta = LinkMLMeta({'default_prefix': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/schema.yaml#',
+     'description': 'Combined source data schemas.',
+     'id': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/schema.yaml#',
+     'imports': ['./assemblies',
+                 './organisms',
+                 './workflow_categories',
+                 './workflows'],
+     'name': 'schema',
+     'prefixes': {'linkml': {'prefix_prefix': 'linkml',
+                             'prefix_reference': 'https://w3id.org/linkml/'}},
+     'source_file': './catalog/schema/schema.yaml'} )
+
+class OrganismPloidy(str, Enum):
+    """
+    Possible ploidies of an organism.
+    """
+    DIPLOID = "DIPLOID"
+    HAPLOID = "HAPLOID"
+    POLYPLOID = "POLYPLOID"
+
+
+class WorkflowCategoryId(str, Enum):
+    """
+    Set of IDs of workflow categories.
+    """
+    VARIANT_CALLING = "VARIANT_CALLING"
+    TRANSCRIPTOMICS = "TRANSCRIPTOMICS"
+    REGULATION = "REGULATION"
+    ASSEMBLY = "ASSEMBLY"
+    GENOME_COMPARISONS = "GENOME_COMPARISONS"
+    PROTEIN_FOLDING = "PROTEIN_FOLDING"
+    OTHER = "OTHER"
+
+
+class WorkflowParameterVariable(str, Enum):
+    """
+    Possible variables that can be inserted into workflow parameters.
+    """
+    ASSEMBLY_ID = "ASSEMBLY_ID"
+    ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL"
+    GENE_MODEL_URL = "GENE_MODEL_URL"
+
+
+class WorkflowPloidy(str, Enum):
+    """
+    Possible ploidies supported by workflows.
+    """
+    ANY = "ANY"
+    DIPLOID = "DIPLOID"
+    HAPLOID = "HAPLOID"
+    POLYPLOID = "POLYPLOID"
+
+
+
+class Assemblies(ConfiguredBaseModel):
+    """
+    Object containing list of assemblies.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/assemblies.yaml#',
+         'tree_root': True})
+
+    assemblies: List[Assembly] = Field(default=..., description="""List of assemblies.""", json_schema_extra = { "linkml_meta": {'alias': 'assemblies', 'domain_of': ['Assemblies']} })
+
+
+class Assembly(ConfiguredBaseModel):
+    """
+    An assembly.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/assemblies.yaml#'})
+
+    accession: str = Field(default=..., description="""The assembly's accession.""", json_schema_extra = { "linkml_meta": {'alias': 'accession', 'domain_of': ['Assembly']} })
+
+
+class Organisms(ConfiguredBaseModel):
+    """
+    Object containing list of organisms.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/organisms.yaml#',
+         'tree_root': True})
+
+    organisms: List[Organism] = Field(default=..., description="""List of organisms.""", json_schema_extra = { "linkml_meta": {'alias': 'organisms', 'domain_of': ['Organisms']} })
+
+
+class Organism(ConfiguredBaseModel):
+    """
+    Info for an organism.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/organisms.yaml#'})
+
+    taxonomy_id: int = Field(default=..., description="""The organism's NCBI taxonomy ID.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Workflow']} })
+    ploidy: List[OrganismPloidy] = Field(default=..., description="""The ploidies that the organism may have.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+
+
+class WorkflowCategories(ConfiguredBaseModel):
+    """
+    Object containing list of workflow categories.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflow_categories.yaml#',
+         'tree_root': True})
+
+    workflow_categories: List[WorkflowCategory] = Field(default=..., description="""List of workflow categories.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_categories', 'domain_of': ['WorkflowCategories']} })
+
+
+class WorkflowCategory(ConfiguredBaseModel):
+    """
+    Workflow category.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflow_categories.yaml#'})
+
+    category: WorkflowCategoryId = Field(default=..., description="""The ID of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['WorkflowCategory']} })
+    name: str = Field(default=..., description="""The display name of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['WorkflowCategory']} })
+    description: str = Field(default=..., description="""The description of the workflow category.""", json_schema_extra = { "linkml_meta": {'alias': 'description', 'domain_of': ['WorkflowCategory']} })
+
+
+class Workflows(ConfiguredBaseModel):
+    """
+    Object containing list of workflows.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#',
+         'tree_root': True})
+
+    workflows: List[Workflow] = Field(default=..., description="""List of workflows.""", json_schema_extra = { "linkml_meta": {'alias': 'workflows', 'domain_of': ['Workflows']} })
+
+
+class Workflow(ConfiguredBaseModel):
+    """
+    A workflow.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#'})
+
+    trs_id: str = Field(default=..., description="""The workflow's TRS ID.""", json_schema_extra = { "linkml_meta": {'alias': 'trs_id', 'domain_of': ['Workflow']} })
+    categories: List[WorkflowCategoryId] = Field(default=..., description="""The IDs of the categories the workflow belongs to.""", json_schema_extra = { "linkml_meta": {'alias': 'categories', 'domain_of': ['Workflow']} })
+    workflow_name: str = Field(default=..., description="""The display name of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_name', 'domain_of': ['Workflow']} })
+    workflow_description: str = Field(default=..., description="""The description of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_description', 'domain_of': ['Workflow']} })
+    ploidy: WorkflowPloidy = Field(default=..., description="""The ploidy supported by the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'ploidy', 'domain_of': ['Organism', 'Workflow']} })
+    taxonomy_id: Optional[int] = Field(default=None, description="""The NCBI ID of the taxon supported by the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'taxonomy_id', 'domain_of': ['Organism', 'Workflow']} })
+    parameters: List[WorkflowParameter] = Field(default=..., description="""The parameters of the workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'parameters', 'domain_of': ['Workflow']} })
+    active: bool = Field(default=..., description="""Determines if workflow should be included.""", json_schema_extra = { "linkml_meta": {'alias': 'active', 'domain_of': ['Workflow']} })
+
+
+class WorkflowParameter(ConfiguredBaseModel):
+    """
+    A parameter that is provided to a workflow; must include a source for the parameter's value in order to be provided.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/workflows.yaml#'})
+
+    key: str = Field(default=..., description="""The key in which the parameter will be set.""", json_schema_extra = { "linkml_meta": {'alias': 'key', 'domain_of': ['WorkflowParameter']} })
+    variable: Optional[WorkflowParameterVariable] = Field(default=None, description="""A variable to substitute in as the value of the parameter.""", json_schema_extra = { "linkml_meta": {'alias': 'variable', 'domain_of': ['WorkflowParameter']} })
+    type_guide: Optional[Any] = Field(default=None, description="""Arbitrary data describing the type of the parameter, intended only as convenient reference for maintainers.""", json_schema_extra = { "linkml_meta": {'alias': 'type_guide', 'domain_of': ['WorkflowParameter']} })
+
+
+# Model rebuild
+# see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
+Assemblies.model_rebuild()
+Assembly.model_rebuild()
+Organisms.model_rebuild()
+Organism.model_rebuild()
+WorkflowCategories.model_rebuild()
+WorkflowCategory.model_rebuild()
+Workflows.model_rebuild()
+Workflow.model_rebuild()
+WorkflowParameter.model_rebuild()
+

--- a/catalog/build/py/iwc_manifest_to_workflows_yaml.py
+++ b/catalog/build/py/iwc_manifest_to_workflows_yaml.py
@@ -108,7 +108,6 @@ def merge_into_existing():
             current_workflow_parameter_keys = {param.key for param in current_workflow_input.parameters}
             for param in existing_workflow_input.parameters:
                 if param.key not in current_workflow_parameter_keys:
-                    print(param.key, current_workflow_parameter_keys)
                     # Should be rare, but can happen.
                     raise Exception(
                         f"{param.key} specified but is not part of updated workflow {current_workflow_input.trs_id}! Review and fix manually"

--- a/catalog/build/ts/build-catalog.ts
+++ b/catalog/build/ts/build-catalog.ts
@@ -4,6 +4,7 @@ import YAML from "yaml";
 import {
   BRCDataCatalogGenome,
   BRCDataCatalogOrganism,
+  Workflow,
   WorkflowCategory,
 } from "../../../app/apis/catalog/brc-analytics-catalog/common/entities";
 import {
@@ -188,7 +189,7 @@ function buildWorkflow(
   workflowCategories: WorkflowCategory[],
   {
     categories,
-    parameters: parameters,
+    parameters: sourceParameters,
     ploidy,
     taxonomy_id: taxonomyId,
     trs_id: trsId,
@@ -196,20 +197,25 @@ function buildWorkflow(
     workflow_name: workflowName,
   }: SourceWorkflow
 ): void {
+  const parameters = [];
+  for (const { key, variable } of sourceParameters) {
+    if (variable) parameters.push({ key, variable });
+  }
+  const workflow: Workflow = {
+    parameters,
+    ploidy,
+    taxonomyId: typeof taxonomyId === "number" ? String(taxonomyId) : null,
+    trsId,
+    workflowDescription,
+    workflowName,
+  };
   for (const category of categories) {
     const workflowCategory = workflowCategories.find(
       (c) => c.category === category
     );
     if (!workflowCategory)
       throw new Error(`Unknown workflow category: ${category}`);
-    workflowCategory.workflows.push({
-      parameters,
-      ploidy,
-      taxonomyId: typeof taxonomyId === "number" ? String(taxonomyId) : null,
-      trsId,
-      workflowDescription,
-      workflowName,
-    });
+    workflowCategory.workflows.push(workflow);
   }
 }
 

--- a/catalog/output/workflows.json
+++ b/catalog/output/workflows.json
@@ -5,17 +5,16 @@
     "name": "Variant calling",
     "workflows": [
       {
-        "parameters": {
-          "Paired Collection": {
-            "class": "Collection",
-            "ext": [
-              "fastqsanger",
-              "fastqsanger.gz"
-            ]
+        "parameters": [
+          {
+            "key": "Annotation GTF",
+            "variable": "GENE_MODEL_URL"
           },
-          "Annotation GTF": "{{ gene_model_url }}",
-          "Genome fasta": "{{ assembly_fasta_url }}"
-        },
+          {
+            "key": "Genome fasta",
+            "variable": "ASSEMBLY_FASTA_URL"
+          }
+        ],
         "ploidy": "HAPLOID",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/haploid-variant-calling-wgs-pe/main/versions/v0.1",
@@ -30,10 +29,16 @@
     "name": "Transcriptomics",
     "workflows": [
       {
-        "parameters": {
-          "reference genome": "{{ assembly_id }}",
-          "gtf": "{{ gene_model_url }}"
-        },
+        "parameters": [
+          {
+            "key": "reference genome",
+            "variable": "ASSEMBLY_ID"
+          },
+          {
+            "key": "gtf",
+            "variable": "GENE_MODEL_URL"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex/versions/v0.6.2",
@@ -41,10 +46,16 @@
         "workflowName": "Single-Cell RNA-seq Preprocessing: 10X Genomics CellPlex Multiplexed Samples"
       },
       {
-        "parameters": {
-          "reference genome": "{{ assembly_id }}",
-          "gtf": "{{ gene_model_url }}"
-        },
+        "parameters": [
+          {
+            "key": "reference genome",
+            "variable": "ASSEMBLY_ID"
+          },
+          {
+            "key": "gtf",
+            "variable": "GENE_MODEL_URL"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3/versions/v0.6.2",
@@ -52,10 +63,16 @@
         "workflowName": "Single-Cell RNA-seq Preprocessing: 10X Genomics v3 to Seurat and Scanpy Compatible Format"
       },
       {
-        "parameters": {
-          "Reference genome": "{{ assembly_id }}",
-          "GTF file of annotation": "{{ gene_model_url }}"
-        },
+        "parameters": [
+          {
+            "key": "Reference genome",
+            "variable": "ASSEMBLY_ID"
+          },
+          {
+            "key": "GTF file of annotation",
+            "variable": "GENE_MODEL_URL"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/rnaseq-pe/main/versions/v1.2",
@@ -63,10 +80,16 @@
         "workflowName": "RNA-Seq Analysis: Paired-End Read Processing and Quantification"
       },
       {
-        "parameters": {
-          "Reference genome": "{{ assembly_id }}",
-          "GTF file of annotation": "{{ gene_model_url }}"
-        },
+        "parameters": [
+          {
+            "key": "Reference genome",
+            "variable": "ASSEMBLY_ID"
+          },
+          {
+            "key": "GTF file of annotation",
+            "variable": "GENE_MODEL_URL"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/rnaseq-sr/main/versions/v1.2",
@@ -81,9 +104,12 @@
     "name": "Regulation",
     "workflows": [
       {
-        "parameters": {
-          "assembly_id": "{{ assembly_id }}"
-        },
+        "parameters": [
+          {
+            "key": "reference_genome",
+            "variable": "ASSEMBLY_ID"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/atacseq/main/versions/v1.0",
@@ -91,9 +117,12 @@
         "workflowName": "ATAC-seq Analysis: Chromatin Accessibility Profiling"
       },
       {
-        "parameters": {
-          "assembly_id": "{{ assembly_id }}"
-        },
+        "parameters": [
+          {
+            "key": "reference_genome",
+            "variable": "ASSEMBLY_ID"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/chipseq-pe/main/versions/v0.14",
@@ -101,9 +130,12 @@
         "workflowName": "ChIP-seq Analysis: Paired-End Read Processing"
       },
       {
-        "parameters": {
-          "assembly_id": "{{ assembly_id }}"
-        },
+        "parameters": [
+          {
+            "key": "reference_genome",
+            "variable": "ASSEMBLY_ID"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/chipseq-sr/main/versions/v0.14",
@@ -111,7 +143,7 @@
         "workflowName": "ChIP-seq Analysis: Single-End Read Processing"
       },
       {
-        "parameters": {},
+        "parameters": [],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/consensus-peaks/consensus-peaks-atac-cutandrun/versions/v1.3",
@@ -119,9 +151,12 @@
         "workflowName": "Consensus Peak Calling for ATAC-seq and CUT&RUN Replicates"
       },
       {
-        "parameters": {
-          "assembly_id": "{{ assembly_id }}"
-        },
+        "parameters": [
+          {
+            "key": "reference_genome",
+            "variable": "ASSEMBLY_ID"
+          }
+        ],
         "ploidy": "ANY",
         "taxonomyId": null,
         "trsId": "#workflow/github.com/iwc-workflows/cutandrun/main/versions/v0.14",

--- a/catalog/schema/enums/workflow_parameter_variable.yaml
+++ b/catalog/schema/enums/workflow_parameter_variable.yaml
@@ -1,0 +1,10 @@
+id: https://github.com/galaxyproject/brc-analytics/blob/main/catalog/schema/enums/workflow_parameter_variable.yaml#
+name: enums_workflow_parameter_variable
+
+enums:
+  WorkflowParameterVariable:
+    description: Possible variables that can be inserted into workflow parameters.
+    permissible_values:
+      ASSEMBLY_ID:
+      ASSEMBLY_FASTA_URL:
+      GENE_MODEL_URL:

--- a/catalog/schema/generated/schema.ts
+++ b/catalog/schema/generated/schema.ts
@@ -21,6 +21,15 @@ export enum WorkflowCategoryId {
     OTHER = "OTHER",
 };
 /**
+* Possible variables that can be inserted into workflow parameters.
+*/
+export enum WorkflowParameterVariable {
+    
+    ASSEMBLY_ID = "ASSEMBLY_ID",
+    ASSEMBLY_FASTA_URL = "ASSEMBLY_FASTA_URL",
+    GENE_MODEL_URL = "GENE_MODEL_URL",
+};
+/**
 * Possible ploidies supported by workflows.
 */
 export enum WorkflowPloidy {
@@ -92,7 +101,9 @@ export interface WorkflowCategory {
 }
 
 
-
+/**
+ * Placeholder type; used avoid unnecessary restrictions on the `type_guide` slot.
+ */
 export interface Any {
 }
 
@@ -114,18 +125,31 @@ export interface Workflow {
     trs_id: string,
     /** The IDs of the categories the workflow belongs to. */
     categories: WorkflowCategoryId[],
-    /** The ploidy supported by the workflow. */
-    ploidy: WorkflowPloidy,
-    /** The NCBI ID of the taxon supported by the workflow. */
-    taxonomy_id?: number | null,
     /** The display name of the workflow. */
     workflow_name: string,
     /** The description of the workflow. */
     workflow_description: string,
-    /** The parameters of the workflow. Dictionary with arbitrary depth, string keys and primitive values. */
-    parameters?: Any,
+    /** The ploidy supported by the workflow. */
+    ploidy: WorkflowPloidy,
+    /** The NCBI ID of the taxon supported by the workflow. */
+    taxonomy_id?: number | null,
+    /** The parameters of the workflow. */
+    parameters: WorkflowParameter[],
     /** Determines if workflow should be included. */
     active: boolean,
+}
+
+
+/**
+ * A parameter that is provided to a workflow; must include a source for the parameter's value in order to be provided.
+ */
+export interface WorkflowParameter {
+    /** The key in which the parameter will be set. */
+    key: string,
+    /** A variable to substitute in as the value of the parameter. */
+    variable?: WorkflowParameterVariable | null,
+    /** Arbitrary data describing the type of the parameter, intended only as convenient reference for maintainers. */
+    type_guide?: Any | null,
 }
 
 

--- a/catalog/schema/generated/workflows.json
+++ b/catalog/schema/generated/workflows.json
@@ -2,7 +2,7 @@
     "$defs": {
         "Any": {
             "additionalProperties": true,
-            "description": "",
+            "description": "Placeholder type; used avoid unnecessary restrictions on the `type_guide` slot.",
             "title": "Any",
             "type": [
                 "null",
@@ -28,15 +28,11 @@
                     "type": "array"
                 },
                 "parameters": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/Any"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "The parameters of the workflow. Dictionary with arbitrary depth, string keys and primitive values."
+                    "description": "The parameters of the workflow.",
+                    "items": {
+                        "$ref": "#/$defs/WorkflowParameter"
+                    },
+                    "type": "array"
                 },
                 "ploidy": {
                     "$ref": "#/$defs/WorkflowPloidy",
@@ -65,9 +61,10 @@
             "required": [
                 "trs_id",
                 "categories",
-                "ploidy",
                 "workflow_name",
                 "workflow_description",
+                "ploidy",
+                "parameters",
                 "active"
             ],
             "title": "Workflow",
@@ -85,6 +82,46 @@
                 "OTHER"
             ],
             "title": "WorkflowCategoryId",
+            "type": "string"
+        },
+        "WorkflowParameter": {
+            "additionalProperties": false,
+            "description": "A parameter that is provided to a workflow; must include a source for the parameter's value in order to be provided.",
+            "properties": {
+                "key": {
+                    "description": "The key in which the parameter will be set.",
+                    "type": "string"
+                },
+                "type_guide": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Any"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Arbitrary data describing the type of the parameter, intended only as convenient reference for maintainers."
+                },
+                "variable": {
+                    "$ref": "#/$defs/WorkflowParameterVariable",
+                    "description": "A variable to substitute in as the value of the parameter."
+                }
+            },
+            "required": [
+                "key"
+            ],
+            "title": "WorkflowParameter",
+            "type": "object"
+        },
+        "WorkflowParameterVariable": {
+            "description": "Possible variables that can be inserted into workflow parameters.",
+            "enum": [
+                "ASSEMBLY_ID",
+                "ASSEMBLY_FASTA_URL",
+                "GENE_MODEL_URL"
+            ],
+            "title": "WorkflowParameterVariable",
             "type": "string"
         },
         "WorkflowPloidy": {

--- a/catalog/schema/scripts/gen-schema.sh
+++ b/catalog/schema/scripts/gen-schema.sh
@@ -2,6 +2,9 @@
 
 source ./catalog/schema/scripts/source-file-schema-names.sh
 
+# Generate Pydantic models for all source data types
+gen-pydantic ./catalog/schema/schema.yaml > ./catalog/build/py/generated_schema/schema.py
+
 # Generate TypeScript definitions for all source data types
 python3 ./catalog/schema/scripts/gen-typescript.py ./catalog/schema/schema.yaml > ./catalog/schema/generated/schema.ts
 

--- a/catalog/schema/workflows.yaml
+++ b/catalog/schema/workflows.yaml
@@ -8,12 +8,13 @@ prefixes:
 imports:
   - linkml:types
   - ./enums/workflow_category_id
+  - ./enums/workflow_parameter_variable
   - ./enums/workflow_ploidy
 
 classes:
   Any:
     class_uri: linkml:Any
-    description: "Placeholder for {[key: string]: string} type."
+    description: Placeholder type; used avoid unnecessary restrictions on the `type_guide` slot.
 
   Workflows:
     description: Object containing list of workflows.
@@ -37,14 +38,6 @@ classes:
         multivalued: true
         required: true
         range: WorkflowCategoryId
-      ploidy:
-        description: The ploidy supported by the workflow.
-        required: true
-        range: WorkflowPloidy
-      taxonomy_id:
-        description: The NCBI ID of the taxon supported by the workflow.
-        required: false
-        range: integer
       workflow_name:
         description: The display name of the workflow.
         required: true
@@ -53,11 +46,36 @@ classes:
         description: The description of the workflow.
         required: true
         range: string
-      parameters:
-        description: The parameters of the workflow. Dictionary with arbitrary depth, string keys and primitive values.
+      ploidy:
+        description: The ploidy supported by the workflow.
+        required: true
+        range: WorkflowPloidy
+      taxonomy_id:
+        description: The NCBI ID of the taxon supported by the workflow.
         required: false
-        range: Any
+        range: integer
+      parameters:
+        description: The parameters of the workflow.
+        required: true
+        multivalued: true
+        range: WorkflowParameter
       active:
         description: Determines if workflow should be included.
         required: true
         range: boolean
+
+  WorkflowParameter:
+    description: A parameter that is provided to a workflow; must include a source for the parameter's value in order to be provided.
+    attributes:
+      key:
+        description: The key in which the parameter will be set.
+        required: true
+        range: string
+      variable:
+        description: A variable to substitute in as the value of the parameter.
+        required: false
+        range: WorkflowParameterVariable
+      type_guide:
+        description: Arbitrary data describing the type of the parameter, intended only as convenient reference for maintainers.
+        required: false
+        range: Any

--- a/catalog/source/workflows.yml
+++ b/catalog/source/workflows.yml
@@ -8,8 +8,9 @@ workflows:
       and assembly graph
     ploidy: ANY
     parameters:
-      Input sequence reads:
-        class: File
+      - key: Input sequence reads
+        type_guide:
+          class: File
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/atacseq/main/versions/v1.0"
     categories:
@@ -25,7 +26,8 @@ workflows:
       peaks) and fragment length distribution plots for quality assessment.
     ploidy: ANY
     parameters:
-      assembly_id: "{{ assembly_id }}"
+      - key: reference_genome
+        variable: ASSEMBLY_ID
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/average-bigwig-between-replicates/main/versions/v0.2"
     categories:
@@ -40,10 +42,12 @@ workflows:
       named after the common sample prefix (without the replicate ID suffix).
     ploidy: ANY
     parameters:
-      Bigwig to average:
-        class: Collection
-      bin_size:
-        class: integer
+      - key: Bigwig to average
+        type_guide:
+          class: Collection
+      - key: bin_size
+        type_guide:
+          class: integer
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/bacterial-genome-assembly/main/versions/v1.1.5"
     categories:
@@ -54,20 +58,22 @@ workflows:
       of quality metrics and reports
     ploidy: ANY
     parameters:
-      Input adapter trimmed sequence reads (forward):
-        class: File
-        ext:
-          - fastq
-          - fastq.gz
-          - fastqsanger
-          - fastqsanger.gz
-      Input adapter trimmed sequence reads (reverse):
-        class: File
-        ext:
-          - fastq
-          - fastq.gz
-          - fastqsanger
-          - fastqsanger.gz
+      - key: Input adapter trimmed sequence reads (forward)
+        type_guide:
+          class: File
+          ext:
+            - fastq
+            - fastq.gz
+            - fastqsanger
+            - fastqsanger.gz
+      - key: Input adapter trimmed sequence reads (reverse)
+        type_guide:
+          class: File
+          ext:
+            - fastq
+            - fastq.gz
+            - fastqsanger
+            - fastqsanger.gz
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/baredsc/baredSC-1d-logNorm/versions/v0.6"
     categories:
@@ -81,15 +87,19 @@ workflows:
       of components in heterogeneous cell populations.
     ploidy: ANY
     parameters:
-      Tabular with raw expression values:
-        class: File
-        ext: tabular
-      Gene name:
-        class: text
-      Maximum value in logNorm:
-        class: float
-      Maximum number of Gaussians to study:
-        class: integer
+      - key: Tabular with raw expression values
+        type_guide:
+          class: File
+          ext: tabular
+      - key: Gene name
+        type_guide:
+          class: text
+      - key: Maximum value in logNorm
+        type_guide:
+          class: float
+      - key: Maximum number of Gaussians to study
+        type_guide:
+          class: integer
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/baredsc/baredSC-2d-logNorm/versions/v0.6"
     categories:
@@ -103,21 +113,28 @@ workflows:
       number of components in heterogeneous cell populations.
     ploidy: ANY
     parameters:
-      Tabular with raw expression values:
-        class: File
-        ext: tabular
-      Gene name for x axis:
-        class: text
-      maximum value in logNorm for x-axis:
-        class: float
-      Gene name for y axis:
-        class: text
-      maximum value in logNorm for y-axis:
-        class: float
-      Maximum number of Gaussians to study:
-        class: integer
-      compute p-value:
-        class: boolean
+      - key: Tabular with raw expression values
+        type_guide:
+          class: File
+          ext: tabular
+      - key: Gene name for x axis
+        type_guide:
+          class: text
+      - key: maximum value in logNorm for x-axis
+        type_guide:
+          class: float
+      - key: Gene name for y axis
+        type_guide:
+          class: text
+      - key: maximum value in logNorm for y-axis
+        type_guide:
+          class: float
+      - key: Maximum number of Gaussians to study
+        type_guide:
+          class: integer
+      - key: compute p-value
+        type_guide:
+          class: boolean
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/brew3r/main/versions/v0.2"
     categories:
@@ -132,18 +149,23 @@ workflows:
       in single-cell and bulk RNA-seq experiments.
     ploidy: ANY
     parameters:
-      Input gtf:
-        class: File
-        ext: gtf
-      BAM collection:
-        class: Collection
-        ext: bam
-      strandedness:
-        class: text
-      minimum coverage:
-        class: integer
-      minimum FPKM for merge:
-        class: float
+      - key: Input gtf
+        type_guide:
+          class: File
+          ext: gtf
+      - key: BAM collection
+        type_guide:
+          class: Collection
+          ext: bam
+      - key: strandedness
+        type_guide:
+          class: text
+      - key: minimum coverage
+        type_guide:
+          class: integer
+      - key: minimum FPKM for merge
+        type_guide:
+          class: float
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/chipseq-pe/main/versions/v0.14"
     categories:
@@ -158,7 +180,8 @@ workflows:
       downstream analysis.
     ploidy: ANY
     parameters:
-      assembly_id: "{{ assembly_id }}"
+      - key: reference_genome
+        variable: ASSEMBLY_ID
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/chipseq-sr/main/versions/v0.14"
     categories:
@@ -173,7 +196,8 @@ workflows:
       downstream analysis.
     ploidy: ANY
     parameters:
-      assembly_id: "{{ assembly_id }}"
+      - key: reference_genome
+        variable: ASSEMBLY_ID
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/consensus-peaks/consensus-peaks-atac-cutandrun/versions/v1.3"
     categories:
@@ -187,7 +211,7 @@ workflows:
       on the combined normalized data, and retains only peaks whose summits overlap
       with intersections from a user-defined minimum number of replicates.
     ploidy: ANY
-    parameters: {}
+    parameters: []
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/consensus-peaks/consensus-peaks-chip-pe/versions/v1.3"
     categories:
@@ -201,7 +225,7 @@ workflows:
       normalized data, and retains only peaks whose summits overlap with intersections
       from a user-defined minimum number of replicates.
     ploidy: ANY
-    parameters: {}
+    parameters: []
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/consensus-peaks/consensus-peaks-chip-sr/versions/v1.3"
     categories:
@@ -215,7 +239,7 @@ workflows:
       normalized data, and retains only peaks whose summits overlap with intersections
       from a user-defined minimum number of replicates.
     ploidy: ANY
-    parameters: {}
+    parameters: []
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/cutandrun/main/versions/v0.14"
     categories:
@@ -230,7 +254,8 @@ workflows:
       characteristic of CUT&RUN/CUT&TAG experiments.
     ploidy: ANY
     parameters:
-      assembly_id: "{{ assembly_id }}"
+      - key: reference_genome
+        variable: ASSEMBLY_ID
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex/versions/v0.6.2"
     categories:
@@ -247,8 +272,10 @@ workflows:
       (Read10X function).
     ploidy: ANY
     parameters:
-      reference genome: "{{ assembly_id }}"
-      gtf: "{{ gene_model_url }}"
+      - key: reference genome
+        variable: ASSEMBLY_ID
+      - key: gtf
+        variable: GENE_MODEL_URL
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3/versions/v0.6.2"
     categories:
@@ -263,8 +290,10 @@ workflows:
       Seurat/Scanpy (Read10X function).
     ploidy: ANY
     parameters:
-      reference genome: "{{ assembly_id }}"
-      gtf: "{{ gene_model_url }}"
+      - key: reference genome
+        variable: ASSEMBLY_ID
+      - key: gtf
+        variable: GENE_MODEL_URL
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/generic-variant-calling-wgs-pe/main/versions/v0.1.1"
     categories:
@@ -275,16 +304,19 @@ workflows:
       in GenBank format
     ploidy: ANY
     parameters:
-      Paired Collection:
-        class: Collection
-        ext:
-          - fastqsanger
-          - fastqsanger.gz
-      GenBank genome:
-        class: File
-        ext: genbank
-      Name for genome database:
-        class: text
+      - key: Paired Collection
+        type_guide:
+          class: Collection
+          ext:
+            - fastqsanger
+            - fastqsanger.gz
+      - key: GenBank genome
+        type_guide:
+          class: File
+          ext: genbank
+      - key: Name for genome database
+        type_guide:
+          class: text
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/goseq/main/versions/v0.1"
     categories:
@@ -300,19 +332,24 @@ workflows:
       as KEGG pathway enrichment results.
     ploidy: ANY
     parameters:
-      Select genome to use:
-        class: text
-      Differential expression result:
-        class: File
-        ext: tabular
-      Select gene ID format:
-        class: text
-      gene length:
-        class: File
-        ext: tabular
-      KEGG pathways:
-        class: File
-        ext: tabular
+      - key: Select genome to use
+        type_guide:
+          class: text
+      - key: Differential expression result
+        type_guide:
+          class: File
+          ext: tabular
+      - key: Select gene ID format
+        type_guide:
+          class: text
+      - key: gene length
+        type_guide:
+          class: File
+          ext: tabular
+      - key: KEGG pathways
+        type_guide:
+          class: File
+          ext: tabular
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/haploid-variant-calling-wgs-pe/main/versions/v0.1"
     categories:
@@ -323,13 +360,16 @@ workflows:
       GenBank format
     ploidy: HAPLOID
     parameters:
-      Paired Collection:
-        class: Collection
-        ext:
-          - fastqsanger
-          - fastqsanger.gz
-      Annotation GTF: "{{ gene_model_url }}"
-      Genome fasta: "{{ assembly_fasta_url }}"
+      - key: Paired Collection
+        type_guide:
+          class: Collection
+          ext:
+            - fastqsanger
+            - fastqsanger.gz
+      - key: Annotation GTF
+        variable: GENE_MODEL_URL
+      - key: Genome fasta
+        variable: ASSEMBLY_FASTA_URL
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler/versions/v0.3"
     categories:
@@ -344,26 +384,36 @@ workflows:
       for downstream analysis and visualization.
     ploidy: ANY
     parameters:
-      PE fastq input:
-        class: Collection
-      genome name:
-        class: text
-      Restriction enzyme:
-        class: text
-      No fill-in:
-        class: boolean
-      minimum MAPQ:
-        class: integer
-      Bin size in bp:
-        class: integer
-      Interactions to consider to calculate weights in normalization step:
-        class: text
-      capture region (chromosome):
-        class: text
-      capture region (start):
-        class: integer
-      capture region (end):
-        class: integer
+      - key: PE fastq input
+        type_guide:
+          class: Collection
+      - key: genome name
+        type_guide:
+          class: text
+      - key: Restriction enzyme
+        type_guide:
+          class: text
+      - key: No fill-in
+        type_guide:
+          class: boolean
+      - key: minimum MAPQ
+        type_guide:
+          class: integer
+      - key: Bin size in bp
+        type_guide:
+          class: integer
+      - key: Interactions to consider to calculate weights in normalization step
+        type_guide:
+          class: text
+      - key: capture region (chromosome)
+        type_guide:
+          class: text
+      - key: capture region (start)
+        type_guide:
+          class: integer
+      - key: capture region (end)
+        type_guide:
+          class: integer
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler/versions/v0.3"
     categories:
@@ -378,22 +428,30 @@ workflows:
       ready for multi-resolution contact matrix analysis.
     ploidy: ANY
     parameters:
-      PE fastq input:
-        class: Collection
-      genome name:
-        class: text
-      Restriction enzyme:
-        class: text
-      No fill-in:
-        class: boolean
-      minimum MAPQ:
-        class: integer
-      Bin size in bp:
-        class: integer
-      Interactions to consider to calculate weights in normalization step:
-        class: text
-      region for matrix plotting:
-        class: text
+      - key: PE fastq input
+        type_guide:
+          class: Collection
+      - key: genome name
+        type_guide:
+          class: text
+      - key: Restriction enzyme
+        type_guide:
+          class: text
+      - key: No fill-in
+        type_guide:
+          class: boolean
+      - key: minimum MAPQ
+        type_guide:
+          class: integer
+      - key: Bin size in bp
+        type_guide:
+          class: integer
+      - key: Interactions to consider to calculate weights in normalization step
+        type_guide:
+          class: text
+      - key: region for matrix plotting
+        type_guide:
+          class: text
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/hic-fastq-to-pairs-hicup/versions/v0.3"
     categories:
@@ -409,16 +467,21 @@ workflows:
       high-confidence interaction data.
     ploidy: ANY
     parameters:
-      PE fastq input:
-        class: Collection
-      genome name:
-        class: text
-      Restriction enzyme:
-        class: text
-      No fill-in:
-        class: boolean
-      minimum MAPQ:
-        class: integer
+      - key: PE fastq input
+        type_guide:
+          class: Collection
+      - key: genome name
+        type_guide:
+          class: text
+      - key: Restriction enzyme
+        type_guide:
+          class: text
+      - key: No fill-in
+        type_guide:
+          class: boolean
+      - key: minimum MAPQ
+        type_guide:
+          class: integer
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/hic-hicup-cooler/hic-juicermediumtabix-to-cool-cooler/versions/v0.3"
     categories:
@@ -432,14 +495,18 @@ workflows:
       between different Hi-C analysis ecosystems while maintaining data integrity.
     ploidy: ANY
     parameters:
-      Bin size in bp:
-        class: integer
-      genome name:
-        class: text
-      Juicer Medium Tabix with validPairs:
-        class: Collection
-      Interactions to consider to calculate weights in normalization step:
-        class: text
+      - key: Bin size in bp
+        type_guide:
+          class: integer
+      - key: genome name
+        type_guide:
+          class: text
+      - key: Juicer Medium Tabix with validPairs
+        type_guide:
+          class: Collection
+      - key: Interactions to consider to calculate weights in normalization step
+        type_guide:
+          class: text
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/mapseq-to-ampvis2/main/versions/v0.2"
     categories: []
@@ -450,10 +517,12 @@ workflows:
       MAPseq output datasets to produce structured output files suitable for Ampvis2.
     ploidy: ANY
     parameters:
-      MAPseq OTU tables:
-        class: Collection
-      OTU table metadata:
-        class: File
+      - key: MAPseq OTU tables
+        type_guide:
+          class: Collection
+      - key: OTU table metadata
+        type_guide:
+          class: File
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/polish-with-long-reads/main/versions/v0.1"
     categories:
@@ -462,12 +531,15 @@ workflows:
     workflow_description: Racon polish with long reads, x4
     ploidy: ANY
     parameters:
-      Assembly to be polished:
-        class: File
-      long reads:
-        class: File
-      "minimap setting (for long reads) ":
-        class: text
+      - key: Assembly to be polished
+        type_guide:
+          class: File
+      - key: long reads
+        type_guide:
+          class: File
+      - key: "minimap setting (for long reads) "
+        type_guide:
+          class: text
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/pseudobulk-worflow-decoupler-edger/main/versions/v0.1.1"
     categories:
@@ -482,25 +554,33 @@ workflows:
       visualize significantly differentially expressed genes.
     ploidy: ANY
     parameters:
-      Source AnnData file:
-        class: File
-        ext:
-          - h5
-          - h5ad
-      "Pseudo-bulk: Fields to merge":
-        class: text
-      Group by column:
-        class: text
-      Sample key column:
-        class: text
-      Name Your Raw Counts Layer:
-        class: text
-      Factor fields:
-        class: text
-      Formula:
-        class: text
-      Gene symbol column:
-        class: text
+      - key: Source AnnData file
+        type_guide:
+          class: File
+          ext:
+            - h5
+            - h5ad
+      - key: "Pseudo-bulk: Fields to merge"
+        type_guide:
+          class: text
+      - key: Group by column
+        type_guide:
+          class: text
+      - key: Sample key column
+        type_guide:
+          class: text
+      - key: Name Your Raw Counts Layer
+        type_guide:
+          class: text
+      - key: Factor fields
+        type_guide:
+          class: text
+      - key: Formula
+        type_guide:
+          class: text
+      - key: Gene symbol column
+        type_guide:
+          class: text
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/quality-and-contamination-control/main/versions/v1.1.6"
     categories:
@@ -511,24 +591,28 @@ workflows:
       read cleaning and taxonomy assignation
     ploidy: ANY
     parameters:
-      Input sequence reads (forward):
-        class: File
-        ext:
-          - fastq
-          - fastq.gz
-          - fastqsanger
-          - fastqsanger.gz
-      Input sequence reads (reverse):
-        class: File
-        ext:
-          - fastq
-          - fastq.gz
-          - fastqsanger
-          - fastqsanger.gz
-      Select a taxonomy database:
-        class: text
-      Select a NCBI taxonomy database:
-        class: text
+      - key: Input sequence reads (forward)
+        type_guide:
+          class: File
+          ext:
+            - fastq
+            - fastq.gz
+            - fastqsanger
+            - fastqsanger.gz
+      - key: Input sequence reads (reverse)
+        type_guide:
+          class: File
+          ext:
+            - fastq
+            - fastq.gz
+            - fastqsanger
+            - fastqsanger.gz
+      - key: Select a taxonomy database
+        type_guide:
+          class: text
+      - key: Select a NCBI taxonomy database
+        type_guide:
+          class: text
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/rnaseq-de/main/versions/v0.3"
     categories:
@@ -544,18 +628,24 @@ workflows:
       for simple two-condition experimental designs.
     ploidy: ANY
     parameters:
-      Counts from changed condition:
-        class: Collection
-      Counts from reference condition:
-        class: Collection
-      Count files have header:
-        class: boolean
-      Gene Annotaton:
-        class: File
-      Adjusted p-value threshold:
-        class: float
-      log2 fold change threshold:
-        class: float
+      - key: Counts from changed condition
+        type_guide:
+          class: Collection
+      - key: Counts from reference condition
+        type_guide:
+          class: Collection
+      - key: Count files have header
+        type_guide:
+          class: boolean
+      - key: Gene Annotaton
+        type_guide:
+          class: File
+      - key: Adjusted p-value threshold
+        type_guide:
+          class: float
+      - key: log2 fold change threshold
+        type_guide:
+          class: float
     active: false
   - trs_id: "#workflow/github.com/iwc-workflows/rnaseq-pe/main/versions/v1.2"
     categories:
@@ -571,8 +661,10 @@ workflows:
       both HTSeq-compatible counts and normalized measures for downstream analysis."
     ploidy: ANY
     parameters:
-      Reference genome: "{{ assembly_id }}"
-      GTF file of annotation: "{{ gene_model_url }}"
+      - key: Reference genome
+        variable: ASSEMBLY_ID
+      - key: GTF file of annotation
+        variable: GENE_MODEL_URL
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/rnaseq-sr/main/versions/v1.2"
     categories:
@@ -588,8 +680,10 @@ workflows:
       both HTSeq-compatible counts and normalized measures for downstream analysis."
     ploidy: ANY
     parameters:
-      Reference genome: "{{ assembly_id }}"
-      GTF file of annotation: "{{ gene_model_url }}"
+      - key: Reference genome
+        variable: ASSEMBLY_ID
+      - key: GTF file of annotation
+        variable: GENE_MODEL_URL
     active: true
   - trs_id: "#workflow/github.com/iwc-workflows/variation-reporting/main/versions/v0.1.1"
     categories:
@@ -602,15 +696,19 @@ workflows:
       plot of variants and their allele-frequencies.
     ploidy: ANY
     parameters:
-      Variation data to report:
-        class: Collection
-        ext:
-          - vcf
-          - vcf_bgzip
-      AF Filter:
-        class: float
-      DP Filter:
-        class: integer
-      DP_ALT Filter:
-        class: integer
+      - key: Variation data to report
+        type_guide:
+          class: Collection
+          ext:
+            - vcf
+            - vcf_bgzip
+      - key: AF Filter
+        type_guide:
+          class: float
+      - key: DP Filter
+        type_guide:
+          class: integer
+      - key: DP_ALT Filter
+        type_guide:
+          class: integer
     active: false

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "jest --runInBand",
     "build-brc-db": "esrun catalog/build/ts/build-catalog.ts",
     "build-files-from-ncbi": "python3 ./catalog/build/py/build-files-from-ncbi.py",
+    "iwc-manifest-to-workflows-yaml": "python3 ./catalog/build/py/iwc_manifest_to_workflows_yaml.py --exclude-other",
     "gen-schema": "./catalog/schema/scripts/gen-schema.sh",
     "test-gen-python": "./catalog/schema/scripts/test-gen-python.sh",
     "validate-catalog": "./catalog/schema/scripts/validate-catalog.sh"


### PR DESCRIPTION
(See also base PR galaxyproject#342)

I'm not familiar with what kinds of parameters we might want to add support for in the future, so it's possible the model I've defined is overly restrictive. It works for the kinds of parameters we already support (individual variable values contained in predetermined structures), and I imagine that we could extend the model as we update the app with support for other kinds of parameters, but let me know if there's some obvious conflict between my model and the way in which workflow parameters actually work!

Overview of changes:
- Updated a few parameter names in workflows.yml to be "reference_genome" instead of "assembly_id", as the former apparently doesn't exist and caused an error when running the workflow update script; hopefully this is the correct fix!
- Changed the `parameters` slot from a dictionary to a list of `WorkflowParameter` dicts. The key of the parameter, which was previously given implicitly as a key in the `parameters` dictionary, is now specified in the `key` slot of the `WorkflowParameter`. I believe this is more idiomatic for this app, and IMO is likely the nicest way to make a more exact model work with LinkML.
  - The type information for a parameter, previously given directly in the body of the parameter definition, is now stored under the `type_guide` slot. Since this is just meant to be a hint to human editors, I've left it typed as `Any`.
  - Rather than using strings of the form `{{ name }}` as placeholders for values that are dynamically inserted as workflow parameters, a `WorkflowParameter` may include the `variable` slot, which specifies the to-be-inserted value via the new `WorkflowParameterVariable` enum.
- Moved the workflow update script to `catalog/build/py`.
- Removed the workflow dataclass defined in the script, instead using Pydantic models that are automatically generated by LinkML.
  - The generated file is saved under `catalog/build/py/generated_schema`, which is a deviation from our convention of putting generated schema files in `catalog/schema/generated`; I'm not sure if there's a better way to do this -- using a relative import caused an error, at least when running the script normally.
- Changed the workflows.yml path used in the script to be relative to the repository root, which I believe is consistent with the procedure for running the script that's described in the base PR.
- For convenience, added a command for running the script to package.json.
- Moved ploidy (and taxonomy ID) in the workflow schema to reflect the established order in the workflows.yml catalog file, since the ordering in the schema appears to propagate to the data output by Pydantic.